### PR TITLE
Add load single command from a yaml config file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ edition = "2018"
 gtk = "0.8.1"
 glib = "0.9.3"
 gio = "0.8.1"
-yaml-rust = "0.4.4"
+serde = { version = "1.0", features = ["derive"] }
+serde_yaml = "0.8"

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ define execute_cargo
 cargo ${1} --target=$(RUST_OPERATING_TARGET) ${2}
 endef
 
+define execute_cargo_no_target
+cargo ${1}
+endef
+
 define ensure_unix_program_exists
 command -v ${1} >/dev/null 2>&1 || { echo >&2 "Program '${1}' is not installed!"; exit 1; }
 endef
@@ -40,10 +44,10 @@ install: ensure_programs_installed
 	$(call execute_cargo,$@,--path .)
 
 fmt:
-	$(call execute_cargo,$@)
+	$(call execute_cargo_no_target,$@)
 
 fmt_ci:
-	$(call execute_cargo,$@ -- --check)
+	$(call execute_cargo_no_target,fmt -- --check)
 
 build:
 	$(call execute_cargo,$@)

--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,10 @@ install: ensure_programs_installed
 	$(call execute_cargo,$@,--path .)
 
 fmt:
-	cargo fmt
+	$(call execute_cargo,$@)
 
 fmt_ci:
-	cargo fmt -- --check
+	$(call execute_cargo,$@ -- --check)
 
 build:
 	$(call execute_cargo,$@)

--- a/src/command_loader.rs
+++ b/src/command_loader.rs
@@ -1,0 +1,27 @@
+extern crate serde_yaml;
+
+use serde::Deserialize;
+use std::fmt;
+
+#[derive(Debug,Deserialize)]
+pub struct Command {
+    pub name: String,
+    pub run: String
+}
+
+impl fmt::Display for Command {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "('name': {}, 'run': {})", self.name, self.run)
+    }
+}
+
+#[derive(Deserialize)]
+struct CommandFile {
+    commands: Vec<Command>
+}
+
+pub fn get_commands(file_contents: &str) -> Result<Vec<Command>, String> {
+    serde_yaml::from_str(&file_contents)
+        .and_then(|data: CommandFile| Ok(data.commands))
+        .map_err(|error| { error.to_string() })
+}

--- a/src/command_loader.rs
+++ b/src/command_loader.rs
@@ -3,13 +3,13 @@ extern crate serde_yaml;
 use serde::Deserialize;
 use std::fmt;
 
-#[derive(Debug,Deserialize)]
-pub struct Command {
+#[derive(Clone, Debug, Deserialize)]
+pub struct MprocCommand {
     pub name: String,
-    pub run: String
+    pub run: String,
 }
 
-impl fmt::Display for Command {
+impl fmt::Display for MprocCommand {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "('name': {}, 'run': {})", self.name, self.run)
     }
@@ -17,11 +17,11 @@ impl fmt::Display for Command {
 
 #[derive(Deserialize)]
 struct CommandFile {
-    commands: Vec<Command>
+    commands: Vec<MprocCommand>,
 }
 
-pub fn get_commands(file_contents: &str) -> Result<Vec<Command>, String> {
+pub fn get_commands(file_contents: &str) -> Result<Vec<MprocCommand>, String> {
     serde_yaml::from_str(&file_contents)
         .and_then(|data: CommandFile| Ok(data.commands))
-        .map_err(|error| { error.to_string() })
+        .map_err(|error| error.to_string())
 }

--- a/src/machine_process.rs
+++ b/src/machine_process.rs
@@ -3,6 +3,7 @@ use std::io::{BufRead, BufReader};
 use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::{process, thread};
+use crate::command_loader;
 
 pub struct MachineProcess {
     command: &'static str,
@@ -61,13 +62,9 @@ impl SpawnsProcess for MachineProcess {
     }
 }
 
-pub fn run_sample_process(output_buffer: TextBuffer) {
-    if cfg!(windows) {
-        MachineProcess {
-            command: "systeminfo",
-        }
-        .spawn(output_buffer);
-    } else {
-        MachineProcess { command: "lsof" }.spawn(output_buffer);
-    }
+pub fn run_sample_process(output_buffer: TextBuffer, commands: &Vec<command_loader::Command>) {
+    commands.iter().map(|command| {
+        MachineProcess { command: &command.run.as_str() }
+            .spawn(output_buffer);
+    }).collect()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,33 +1,18 @@
-mod machine_process;
-mod main_scene;
-mod process_container;
-mod command_loader;
-
 use gio::prelude::ApplicationExtManual;
 use gio::ApplicationExt;
 use gtk::Application;
+use std::env::args;
 
-use std::fs::{read_to_string};
-use std::env;
+mod command_loader;
+mod machine_process;
+mod main_scene;
+mod process_container;
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    let commands_file_path = &args.get(1).expect(
-        "Please provide a path to CommandFile!"
-    );
+    let args = args().collect::<Vec<_>>().clone();
+    let app = Application::new(Some("com.ddubson.basic"), gio::ApplicationFlags::FLAGS_NONE)
+        .expect("Initialization failed...");
 
-    let contents = read_to_string(commands_file_path)
-        .expect("Something went wrong reading the file.");
-
-    let commands = command_loader::get_commands(&contents).expect(
-        "Unable to read commands!"
-    );
-
-    let app = Application::new(
-        Some("com.ddubson.basic"),
-        gio::ApplicationFlags::FLAGS_NONE,
-    ).expect("Initialization failed...");
-
-    app.connect_activate(|app| main_scene::on_window_activate(app, &commands));
+    app.connect_activate(move |app| main_scene::on_window_activate(app, &args));
     app.run(&vec![]);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,33 @@
 mod machine_process;
 mod main_scene;
 mod process_container;
+mod command_loader;
 
 use gio::prelude::ApplicationExtManual;
 use gio::ApplicationExt;
 use gtk::Application;
 
-fn main() {
-    let app = Application::new(Some("com.ddubson.basic"), gio::ApplicationFlags::FLAGS_NONE)
-        .expect("Initialization failed...");
+use std::fs::{read_to_string};
+use std::env;
 
-    app.connect_activate(|app| main_scene::on_window_activate(app));
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let commands_file_path = &args.get(1).expect(
+        "Please provide a path to CommandFile!"
+    );
+
+    let contents = read_to_string(commands_file_path)
+        .expect("Something went wrong reading the file.");
+
+    let commands = command_loader::get_commands(&contents).expect(
+        "Unable to read commands!"
+    );
+
+    let app = Application::new(
+        Some("com.ddubson.basic"),
+        gio::ApplicationFlags::FLAGS_NONE,
+    ).expect("Initialization failed...");
+
+    app.connect_activate(|app| main_scene::on_window_activate(app, &commands));
     app.run(&vec![]);
 }

--- a/src/main_scene.rs
+++ b/src/main_scene.rs
@@ -1,10 +1,9 @@
-use crate::process_container::ProcessUIContainer;
-use crate::{machine_process, process_container};
 use glib::clone;
-use gtk::{
-    Application, ApplicationWindow, BoxBuilder, ButtonBuilder, ButtonExt, ContainerExt,
-    GtkWindowExt, Orientation, WidgetExt,
-};
+use gtk::{Application, ApplicationWindow, BoxBuilder, ButtonBuilder, ButtonExt, ContainerExt, GtkWindowExt, Orientation, WidgetExt};
+
+use crate::{machine_process, process_container};
+use crate::command_loader::Command;
+use crate::process_container::ProcessUIContainer;
 
 struct WindowConfiguration {
     title: &'static str,
@@ -18,7 +17,7 @@ const STD_WINDOW_CONFIG: WindowConfiguration = WindowConfiguration {
     width: 1200,
 };
 
-pub fn on_window_activate(app: &Application) {
+pub fn on_window_activate(app: &Application, defaultCommands: &Vec<Command>) {
     let window = ApplicationWindow::new(app);
     let button = ButtonBuilder::new().label("Exit mproc!").build();
     button.connect_clicked(clone!(@weak window => move |_| window.destroy()));
@@ -37,5 +36,5 @@ pub fn on_window_activate(app: &Application) {
     window.set_default_size(STD_WINDOW_CONFIG.width, STD_WINDOW_CONFIG.height);
     window.show_all();
 
-    machine_process::run_sample_process(process_container.text_buffer)
+    machine_process::run_sample_process(process_container.text_buffer, defaultCommands)
 }

--- a/src/main_scene.rs
+++ b/src/main_scene.rs
@@ -1,9 +1,11 @@
 use glib::clone;
-use gtk::{Application, ApplicationWindow, BoxBuilder, ButtonBuilder, ButtonExt, ContainerExt, GtkWindowExt, Orientation, WidgetExt};
+use gtk::{
+    Application, ApplicationWindow, BoxBuilder, ButtonBuilder, ButtonExt, ContainerExt,
+    GtkWindowExt, Orientation, WidgetExt,
+};
 
-use crate::{machine_process, process_container};
-use crate::command_loader::Command;
 use crate::process_container::ProcessUIContainer;
+use crate::{machine_process, process_container};
 
 struct WindowConfiguration {
     title: &'static str,
@@ -17,7 +19,7 @@ const STD_WINDOW_CONFIG: WindowConfiguration = WindowConfiguration {
     width: 1200,
 };
 
-pub fn on_window_activate(app: &Application, defaultCommands: &Vec<Command>) {
+pub fn on_window_activate(app: &Application, args: &Vec<String>) {
     let window = ApplicationWindow::new(app);
     let button = ButtonBuilder::new().label("Exit mproc!").build();
     button.connect_clicked(clone!(@weak window => move |_| window.destroy()));
@@ -36,5 +38,5 @@ pub fn on_window_activate(app: &Application, defaultCommands: &Vec<Command>) {
     window.set_default_size(STD_WINDOW_CONFIG.width, STD_WINDOW_CONFIG.height);
     window.show_all();
 
-    machine_process::run_sample_process(process_container.text_buffer, defaultCommands)
+    machine_process::run_sample_process(process_container.text_buffer, args)
 }

--- a/test-data/.mproc.yml
+++ b/test-data/.mproc.yml
@@ -1,6 +1,4 @@
 # This is a sample yaml file used for development purposes only
 commands:
   - name: Command1
-    run: ls -la
-  - name: Command2
-    run: echo hi
+    run: lsof


### PR DESCRIPTION
- Moved the Yaml loading from `main.rs` to `machine_process.rs`
- Rename `Command` struct to `MprocCommand` -- Command is used in the `std` lib so it's better to stay away from ambiguous names
- Restructure the trait SpawnsProcess into just a `spawn` function that takes in an MprocCommand and an output buffer to write to.